### PR TITLE
Fixed bug in ambiguous relation detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalog"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Sven Nilsen <bvssvni@gmail.com>"]
 edition = "2018"
 keywords = ["avatar", "logic", "prolog", "solver", "advancedresearch"]

--- a/source/chu_space.txt
+++ b/source/chu_space.txt
@@ -3,6 +3,9 @@
 // https://www.lesswrong.com/posts/BSpdshJWGAW6TuNzZ/introduction-to-cartesian-frames
 //
 
+// Do not allow multiple `not`s.
+uniq not
+
 // Generate negative roles (this makes them right-exclusive).
 not'(X) : Y :- X : Y, X != not'(Z).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,7 +745,7 @@ pub fn infer(cache: &HashSet<Expr>, filter_cache: &HashSet<Expr>, facts: &[Expr]
                         if let Rel(a2, b2) = e1 {
                             if a2 == a && b2 != b {
                                 if let Ava(av2, _) = &**b2 {
-                                    if av2 != av {
+                                    if uniq || av2 != av {
                                         for e2 in facts {
                                             if let RoleOf(a3, b3) = e2 {
                                                 if a3 == b2 && &**b3 == b_role {
@@ -754,12 +754,6 @@ pub fn infer(cache: &HashSet<Expr>, filter_cache: &HashSet<Expr>, facts: &[Expr]
                                                     if can_add(&new_expr) {return Some(new_expr)};
                                                 }
                                             }
-                                        }
-                                    } else {
-                                        if uniq {
-                                            let new_expr = ambiguous_rel((**a).clone(),
-                                                (**b).clone(), (**b2).clone());
-                                            if can_add(&new_expr) {return Some(new_expr)};
                                         }
                                     }
                                 }


### PR DESCRIPTION
- Bumped to 0.3.2

The old code did not check the role was the same in the unique case.