### PR TITLE
Added "help eval"

### DIFF
--- a/assets/help-equality.txt
+++ b/assets/help-equality.txt
@@ -20,3 +20,5 @@ what the capital is of the country, it is convenient to lift the equality:
 
 When a "has" relation `p(a) => q'(b)` where `uniq q`,
 it is lifted to `p(a) = q'(b)` automatically.
+
+Equalities are lifted into "has" relations automatically.

--- a/assets/help-eval.txt
+++ b/assets/help-eval.txt
@@ -1,0 +1,26 @@
+=== Evaluation ===
+Avalog supports injection of evaluation role into expressions
+for easier evaluation in advanced modeling.
+
+For example:
+
+  x : val
+  (f(x), x)
+  eval val
+  (f(f(x)), x)
+
+The directive `eval val` expands `(f(f(x)), x)` into:
+
+  (f(val(f(x))), x)
+
+Here, `val` is the role used for evaluation.
+Notice that the role is not injected for top expressions.
+
+Similarly `(f(f(f(x))), x)` would be expanded to:
+
+  (f(val(f(val(f(x))))), x)
+
+The directive `no eval` turns off injection of evaluation role.
+
+The reason roles are injected like this,
+is because Avatar Logic can have multiple dimensions of evaluation.

--- a/assets/help.txt
+++ b/assets/help.txt
@@ -22,8 +22,9 @@ Special commands:
 - help pairs          more help about pairs
 - help roles          more help about roles
 - help avatars        more help about avatars
-- help application    more help about application
 - help rules          more help about rules
+- help application    more help about application
+- help eval           more help about evaluation
 - help equality       more help about equality
 - help inequality     more help about inequality
 - help graph          more help about GraphViz export

--- a/examples/avalog_repl.rs
+++ b/examples/avalog_repl.rs
@@ -92,8 +92,9 @@ fn main() {
             "help pairs" => {print_help_pairs(); continue}
             "help roles" => {print_help_roles(); continue}
             "help avatars" => {print_help_avatars(); continue}
-            "help application" => {print_help_application(); continue}
             "help rules" => {print_help_rules(); continue}
+            "help application" => {print_help_application(); continue}
+            "help eval" => {print_help_eval(); continue}
             "help equality" => {print_help_equality(); continue}
             "help inequality" => {print_help_inequality(); continue}
             "help graph" => {print_help_graph(); continue}
@@ -413,8 +414,9 @@ fn print_help_hide() {print!("{}", include_str!("../assets/help-hide.txt"))}
 fn print_help_pairs() {print!("{}", include_str!("../assets/help-pairs.txt"))}
 fn print_help_roles() {print!("{}", include_str!("../assets/help-roles.txt"))}
 fn print_help_avatars() {print!("{}", include_str!("../assets/help-avatars.txt"))}
-fn print_help_application() {print!("{}", include_str!("../assets/help-application.txt"))}
 fn print_help_rules() {print!("{}", include_str!("../assets/help-rules.txt"))}
+fn print_help_application() {print!("{}", include_str!("../assets/help-application.txt"))}
+fn print_help_eval() {print!("{}", include_str!("../assets/help-eval.txt"))}
 fn print_help_equality() {print!("{}", include_str!("../assets/help-equality.txt"))}
 fn print_help_inequality() {print!("{}", include_str!("../assets/help-inequality.txt"))}
 fn print_help_graph() {println!("{}", include_str!("../assets/help-graph.txt"))}


### PR DESCRIPTION
Closes https://github.com/advancedresearch/avalog/issues/124

Changed order of “help rules” and “help application” since application
and evaluation is more difficult to learn.