### PR TITLE
Added support for custom symbol types

### DIFF
--- a/examples/avalog_repl.rs
+++ b/examples/avalog_repl.rs
@@ -136,7 +136,8 @@ fn main() {
                         }
                     }
                 } else if x.starts_with("echo ") {
-                    match parse_str(x[5..].trim(), parent) {
+                    let res: ParseResult = parse_str(x[5..].trim(), parent);
+                    match res {
                         Ok(facts) => {
                             println!("{:#?}", facts);
                             continue;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,9 @@
 extern crate avalog;
 
 fn check(facts: &'static str, goals: &'static str) {
-    use avalog::{solve_with_accelerator, parse, infer, Accelerator};
+    use avalog::{solve_with_accelerator, parse, infer, Accelerator, ParseData};
 
-    let facts = parse(facts).unwrap();
+    let facts: ParseData = parse(facts).unwrap();
     let goals = parse(goals).unwrap();
     assert!(solve_with_accelerator(
         &facts,
@@ -17,9 +17,9 @@ fn check(facts: &'static str, goals: &'static str) {
 }
 
 fn fail(facts: &'static str, goals: &'static str) {
-    use avalog::{solve_with_accelerator, parse, infer, Accelerator};
+    use avalog::{solve_with_accelerator, parse, infer, Accelerator, ParseData};
 
-    let facts = parse(facts).unwrap();
+    let facts: ParseData = parse(facts).unwrap();
     let goals = parse(goals).unwrap();
     assert!(solve_with_accelerator(
         &facts,


### PR DESCRIPTION
Closes https://github.com/advancedresearch/avalog/issues/166

- Added `Symbol` trait
- Added `ParseResult`
- Added `ParseData`
- Renamed `Expr::TailSym` to `TailVar`